### PR TITLE
Add git lfs init

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Install Git LFS
+        run: |
+          git lfs install
+          git lfs pull
       - name: Set up elan
         run: curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
       - name: Build project


### PR DESCRIPTION
This fixes the current CI error that Git LFS is not initialized.

This *does not* let the current codes pass the CI tests, because the current codes do contain errors, especially in file [LeanCopilotTests/LowLevelAPIs.lean](https://github.com/lean-dojo/LeanCopilot/blob/main/LeanCopilotTests/LowLevelAPIs.lean)