### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -11,10 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
     name: Build
     steps:
       - name: Checkout project
@@ -35,10 +32,7 @@ jobs:
         run: ~/.elan/bin/lake build LeanCopilotTests
   test_external:
     needs: build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
     name: Test external
     steps:
       - name: Set up elan

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Build tests
         run: ~/.elan/bin/lake build LeanCopilotTests
   test_external:
-    needs: build
     runs-on: ubuntu-latest
     name: Test external
     steps:


### PR DESCRIPTION
## Update CI

This PR addresses the bug report in #61 .

* Remove x86-64_MacOS from tested architectures in CI, as we no longer release binaries for it.
* Allow CI tests to run on parallel.