### PR TITLE
fix: coe string -> name removed, explicitly call String.toName

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -106,7 +106,7 @@ lean_exe download {
 
 
 lean_lib LeanCopilotTests {
-  globs := #[.submodules "LeanCopilotTests"]
+  globs := #[.submodules "LeanCopilotTests".toName]
 }
 
 


### PR DESCRIPTION
The coercion was removed recently, and it's backwards compatible.