### PR TITLE
Fix string UTF-8 misformatting PANIC

### DIFF
--- a/LeanCopilot/Models/ByT5.lean
+++ b/LeanCopilot/Models/ByT5.lean
@@ -281,7 +281,9 @@ def tokenize (text : String) : Array String :=
 
 
 def detokenize (tokens : Array String) : String :=
-  String.fromUTF8! ⟨tokens.map tokenToByte!⟩
+  match (String.fromUTF8? ⟨tokens.map tokenToByte!⟩) with
+  | some s => s
+  | none => ""
 
 
 def eosToken := "</s>"


### PR DESCRIPTION
This PR fixes the PANIC observed in Issue #113. Apparently the bytes generated from the tokens can potentially be invalid, in which case we return an empty string. This introduces no functional changes other than getting rid of the reported PANIC.

The exact position this warning was throwed is line 40 in `ModelAPIs.lean`. The ultimate cause is in `ByT5.lean` that we modify in this PR.